### PR TITLE
Normalize a request's options

### DIFF
--- a/lib/recombee_api_client/api/add_bookmark.rb
+++ b/lib/recombee_api_client/api/add_bookmark.rb
@@ -26,6 +26,7 @@ module RecombeeApiClient
     def initialize(user_id, item_id, optional = {})
       @user_id = user_id
       @item_id = item_id
+      optional = normalize_optional(optional)
       @timestamp = optional['timestamp']
       @cascade_create = optional['cascadeCreate']
       @optional = optional

--- a/lib/recombee_api_client/api/add_cart_addition.rb
+++ b/lib/recombee_api_client/api/add_cart_addition.rb
@@ -28,6 +28,7 @@ module RecombeeApiClient
     def initialize(user_id, item_id, optional = {})
       @user_id = user_id
       @item_id = item_id
+      optional = normalize_optional(optional)
       @timestamp = optional['timestamp']
       @cascade_create = optional['cascadeCreate']
       @amount = optional['amount']

--- a/lib/recombee_api_client/api/add_detail_view.rb
+++ b/lib/recombee_api_client/api/add_detail_view.rb
@@ -27,6 +27,7 @@ module RecombeeApiClient
     def initialize(user_id, item_id, optional = {})
       @user_id = user_id
       @item_id = item_id
+      optional = normalize_optional(optional)
       @timestamp = optional['timestamp']
       @duration = optional['duration']
       @cascade_create = optional['cascadeCreate']

--- a/lib/recombee_api_client/api/add_purchase.rb
+++ b/lib/recombee_api_client/api/add_purchase.rb
@@ -29,6 +29,7 @@ module RecombeeApiClient
     def initialize(user_id, item_id, optional = {})
       @user_id = user_id
       @item_id = item_id
+      optional = normalize_optional(optional)
       @timestamp = optional['timestamp']
       @cascade_create = optional['cascadeCreate']
       @amount = optional['amount']

--- a/lib/recombee_api_client/api/add_rating.rb
+++ b/lib/recombee_api_client/api/add_rating.rb
@@ -28,6 +28,7 @@ module RecombeeApiClient
       @user_id = user_id
       @item_id = item_id
       @rating = rating
+      optional = normalize_optional(optional)
       @timestamp = optional['timestamp']
       @cascade_create = optional['cascadeCreate']
       @optional = optional

--- a/lib/recombee_api_client/api/batch.rb
+++ b/lib/recombee_api_client/api/batch.rb
@@ -16,6 +16,7 @@ module RecombeeApiClient
     #
     def initialize(requests, optional = {})
       @requests = requests
+      optional = normalize_optional(optional)
       @optional = optional
       @body_parameters = requests_to_batch_hash
       @timeout = requests.map{|r| r.timeout}.reduce(:+)

--- a/lib/recombee_api_client/api/delete_bookmark.rb
+++ b/lib/recombee_api_client/api/delete_bookmark.rb
@@ -25,6 +25,7 @@ module RecombeeApiClient
     def initialize(user_id, item_id, optional = {})
       @user_id = user_id
       @item_id = item_id
+      optional = normalize_optional(optional)
       @timestamp = optional['timestamp']
       @optional = optional
       @timeout = 1000

--- a/lib/recombee_api_client/api/delete_cart_addition.rb
+++ b/lib/recombee_api_client/api/delete_cart_addition.rb
@@ -25,6 +25,7 @@ module RecombeeApiClient
     def initialize(user_id, item_id, optional = {})
       @user_id = user_id
       @item_id = item_id
+      optional = normalize_optional(optional)
       @timestamp = optional['timestamp']
       @optional = optional
       @timeout = 1000

--- a/lib/recombee_api_client/api/delete_detail_view.rb
+++ b/lib/recombee_api_client/api/delete_detail_view.rb
@@ -25,6 +25,7 @@ module RecombeeApiClient
     def initialize(user_id, item_id, optional = {})
       @user_id = user_id
       @item_id = item_id
+      optional = normalize_optional(optional)
       @timestamp = optional['timestamp']
       @optional = optional
       @timeout = 1000

--- a/lib/recombee_api_client/api/delete_purchase.rb
+++ b/lib/recombee_api_client/api/delete_purchase.rb
@@ -25,6 +25,7 @@ module RecombeeApiClient
     def initialize(user_id, item_id, optional = {})
       @user_id = user_id
       @item_id = item_id
+      optional = normalize_optional(optional)
       @timestamp = optional['timestamp']
       @optional = optional
       @timeout = 1000

--- a/lib/recombee_api_client/api/delete_rating.rb
+++ b/lib/recombee_api_client/api/delete_rating.rb
@@ -25,6 +25,7 @@ module RecombeeApiClient
     def initialize(user_id, item_id, optional = {})
       @user_id = user_id
       @item_id = item_id
+      optional = normalize_optional(optional)
       @timestamp = optional['timestamp']
       @optional = optional
       @timeout = 1000

--- a/lib/recombee_api_client/api/delete_view_portion.rb
+++ b/lib/recombee_api_client/api/delete_view_portion.rb
@@ -27,6 +27,7 @@ module RecombeeApiClient
     def initialize(user_id, item_id, optional = {})
       @user_id = user_id
       @item_id = item_id
+      optional = normalize_optional(optional)
       @session_id = optional['sessionId']
       @optional = optional
       @timeout = 1000

--- a/lib/recombee_api_client/api/hash_normalizer.rb
+++ b/lib/recombee_api_client/api/hash_normalizer.rb
@@ -1,0 +1,21 @@
+module RecombeeApiClient
+  ##
+  # Module to convert Ruby conventions to Recombee's API namings
+  #
+  module HashNormalizer
+    def normalize_optional opts
+      opts_new = {}
+      opts.each do |k,v|
+        case k
+        when String then opts_new[camelize(k)] = opts.delete(k)
+        when Symbol then opts_new[camelize(k.to_s)] = opts.delete(k)
+        end
+      end
+      opts_new
+    end
+
+    def camelize str
+      str.gsub(/_(.)/) {|e| $1.upcase}
+    end
+  end
+end

--- a/lib/recombee_api_client/api/insert_to_group.rb
+++ b/lib/recombee_api_client/api/insert_to_group.rb
@@ -27,6 +27,7 @@ module RecombeeApiClient
       @group_id = group_id
       @item_type = item_type
       @item_id = item_id
+      optional = normalize_optional(optional)
       @cascade_create = optional['cascadeCreate']
       @optional = optional
       @timeout = 1000

--- a/lib/recombee_api_client/api/insert_to_series.rb
+++ b/lib/recombee_api_client/api/insert_to_series.rb
@@ -29,6 +29,7 @@ module RecombeeApiClient
       @item_type = item_type
       @item_id = item_id
       @time = time
+      optional = normalize_optional(optional)
       @cascade_create = optional['cascadeCreate']
       @optional = optional
       @timeout = 1000

--- a/lib/recombee_api_client/api/item_based_recommendation.rb
+++ b/lib/recombee_api_client/api/item_based_recommendation.rb
@@ -95,6 +95,7 @@ module RecombeeApiClient
     def initialize(item_id, count, optional = {})
       @item_id = item_id
       @count = count
+      optional = normalize_optional(optional)
       @target_user_id = optional['targetUserId']
       @user_impact = optional['userImpact']
       @filter = optional['filter']

--- a/lib/recombee_api_client/api/list_items.rb
+++ b/lib/recombee_api_client/api/list_items.rb
@@ -61,6 +61,7 @@ module RecombeeApiClient
   #
   #
     def initialize(optional = {})
+      optional = normalize_optional(optional)
       @filter = optional['filter']
       @count = optional['count']
       @offset = optional['offset']

--- a/lib/recombee_api_client/api/list_users.rb
+++ b/lib/recombee_api_client/api/list_users.rb
@@ -55,6 +55,7 @@ module RecombeeApiClient
   #
   #
     def initialize(optional = {})
+      optional = normalize_optional(optional)
       @filter = optional['filter']
       @count = optional['count']
       @offset = optional['offset']

--- a/lib/recombee_api_client/api/merge_users.rb
+++ b/lib/recombee_api_client/api/merge_users.rb
@@ -28,6 +28,7 @@ module RecombeeApiClient
     def initialize(target_user_id, source_user_id, optional = {})
       @target_user_id = target_user_id
       @source_user_id = source_user_id
+      optional = normalize_optional(optional)
       @cascade_create = optional['cascadeCreate']
       @optional = optional
       @timeout = 10000

--- a/lib/recombee_api_client/api/recommend_items_to_item.rb
+++ b/lib/recombee_api_client/api/recommend_items_to_item.rb
@@ -117,6 +117,7 @@ module RecombeeApiClient
       @item_id = item_id
       @target_user_id = target_user_id
       @count = count
+      optional = normalize_optional(optional)
       @user_impact = optional['userImpact']
       @filter = optional['filter']
       @booster = optional['booster']

--- a/lib/recombee_api_client/api/recommend_items_to_user.rb
+++ b/lib/recombee_api_client/api/recommend_items_to_user.rb
@@ -96,6 +96,7 @@ module RecombeeApiClient
     def initialize(user_id, count, optional = {})
       @user_id = user_id
       @count = count
+      optional = normalize_optional(optional)
       @filter = optional['filter']
       @booster = optional['booster']
       @cascade_create = optional['cascadeCreate']

--- a/lib/recombee_api_client/api/recommend_users_to_item.rb
+++ b/lib/recombee_api_client/api/recommend_users_to_item.rb
@@ -84,6 +84,7 @@ module RecombeeApiClient
     def initialize(item_id, count, optional = {})
       @item_id = item_id
       @count = count
+      optional = normalize_optional(optional)
       @filter = optional['filter']
       @booster = optional['booster']
       @cascade_create = optional['cascadeCreate']

--- a/lib/recombee_api_client/api/recommend_users_to_user.rb
+++ b/lib/recombee_api_client/api/recommend_users_to_user.rb
@@ -90,6 +90,7 @@ module RecombeeApiClient
     def initialize(user_id, count, optional = {})
       @user_id = user_id
       @count = count
+      optional = normalize_optional(optional)
       @filter = optional['filter']
       @booster = optional['booster']
       @cascade_create = optional['cascadeCreate']

--- a/lib/recombee_api_client/api/request.rb
+++ b/lib/recombee_api_client/api/request.rb
@@ -3,5 +3,7 @@ module RecombeeApiClient
   # Parent class for API requests
   #
   class ApiRequest
+    require_relative 'hash_normalizer'
+    include RecombeeApiClient::HashNormalizer
   end
 end

--- a/lib/recombee_api_client/api/set_values.rb
+++ b/lib/recombee_api_client/api/set_values.rb
@@ -27,6 +27,7 @@ module RecombeeApiClient
   #
     def initialize( values, optional = {})
       @values = values
+      optional = normalize_optional(optional)
       @cascade_create = optional['cascadeCreate']
       @optional = optional
       @optional.each do |par, _|

--- a/lib/recombee_api_client/api/set_view_portion.rb
+++ b/lib/recombee_api_client/api/set_view_portion.rb
@@ -32,6 +32,7 @@ module RecombeeApiClient
       @user_id = user_id
       @item_id = item_id
       @portion = portion
+      optional = normalize_optional(optional)
       @session_id = optional['sessionId']
       @timestamp = optional['timestamp']
       @cascade_create = optional['cascadeCreate']

--- a/lib/recombee_api_client/api/user_based_recommendation.rb
+++ b/lib/recombee_api_client/api/user_based_recommendation.rb
@@ -83,6 +83,7 @@ module RecombeeApiClient
     def initialize(user_id, count, optional = {})
       @user_id = user_id
       @count = count
+      optional = normalize_optional(optional)
       @filter = optional['filter']
       @booster = optional['booster']
       @allow_nonexistent = optional['allowNonexistent']


### PR DESCRIPTION
In Ruby using symbols in Hash is acceptable. Ruby's convention is to use snake_case and not camelcase.
If a user uses either, then convert to comply with Recombee's convention.